### PR TITLE
Remove nargo tests #8

### DIFF
--- a/circuits/Sudoku/circuits/src/main.nr
+++ b/circuits/Sudoku/circuits/src/main.nr
@@ -74,11 +74,3 @@ fn main(question: pub [Field; 16], answer : [Field; 16]) {
     // Solution Starts Here ..
 }
 
-#[test]
-fn test_sudoku()  {
-    let a:[Field; 16] = [1,0,0,0,0,2,0,0,4,0,0,0,0,0,0,1];
-    let b:[Field; 16] = [1,4,3,2,3,2,1,4,4,1,2,3,2,3,4,1];
-    
-    // If the call does not revert , we assume it is correct.
-    main(a,b);
-}


### PR DESCRIPTION
 #8  
We are removing nargo tests as tests pass even though no solution is implemented by the user. 

While in foundry we would need a plonk file for tests to run. For which a solution is needed.