### PR TITLE
Remove nargo test.

### DIFF
--- a/circuits/Sujiko/circuits/src/main.nr
+++ b/circuits/Sujiko/circuits/src/main.nr
@@ -23,10 +23,3 @@ fn is_equal(a:Field, b:Field) -> pub bool {
     let m = false;
     z| m 
 }
-
-#[test]
-fn test_sujiko() {
-    let question:[Field; 4] = [20, 22, 14, 20];
-    let solution:[Field; 9] = [7, 9, 2, 1, 3, 8, 6,4, 5];
-    main(question, solution);
-}


### PR DESCRIPTION
# Goal:

Clarify testing for user.

## Changes made:

Removed `narog` test at bottom of Sujiko noir circuit.

## Future:

- Ensure testing procedure is clearly documented
- Implement strong Foundry testing
