### PR TITLE
chore: Update puzzles nargo.toml files

### DIFF
--- a/circuits/Addition/Nargo.toml
+++ b/circuits/Addition/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name = "Addition"
 authors = ["RareSkills"]
 compiler_version = "0.4.1"
+type = "bin"
 
 [dependencies]

--- a/circuits/Dot-Product/Nargo.toml
+++ b/circuits/Dot-Product/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name = "Dot_product"
 authors = ["RareSkills"]
 compiler_version = "0.4.1"
+type = "bin"
 
 [dependencies]

--- a/circuits/ForLoop/Nargo.toml
+++ b/circuits/ForLoop/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name = "For_loop"
 authors = ["RareSkills"]
 compiler_version = "0.4.1"
+type = "bin"
 
 [dependencies]

--- a/circuits/Global/Nargo.toml
+++ b/circuits/Global/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name = "Global"
 authors = ["RareSkills"]
 compiler_version = "0.4.1"
+type = "bin"
 
 [dependencies]

--- a/circuits/HelloNoir/circuits/Nargo.toml
+++ b/circuits/HelloNoir/circuits/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name = "hello_noir"
 authors = [""]
 compiler_version = "0.5.1"
+type = "bin"
 
 [dependencies]

--- a/circuits/Max-Edge/Nargo.toml
+++ b/circuits/Max-Edge/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name = "max_edge"
 authors = ["RareSkills"]
 compiler_version = "0.4.1"
+type = "bin"
 
 [dependencies]

--- a/circuits/Module/Nargo.toml
+++ b/circuits/Module/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name = "module"
 authors = ["RareSkills"]
 compiler_version = "0.4.1"
+type = "bin"
 
 [dependencies]

--- a/circuits/Poseidon/Nargo.toml
+++ b/circuits/Poseidon/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name = "poseidon"
 authors = ["RareSkills"]
 compiler_version = "0.4.1"
+type = "bin"
 
 [dependencies]

--- a/circuits/Power/Nargo.toml
+++ b/circuits/Power/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name = "power"
 authors = ["RareSkills"]
 compiler_version = "0.4.1"
+type = "bin"
 
 [dependencies]

--- a/circuits/Range/Nargo.toml
+++ b/circuits/Range/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name = "range"
 authors = ["RareSkills"]
 compiler_version = "0.4.1"
+type = "bin"
 
 [dependencies]

--- a/circuits/Salt/Nargo.toml
+++ b/circuits/Salt/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name = "salt"
 authors = ["RareSkills"]
 compiler_version = "0.4.1"
+type = "bin"
 
 [dependencies]

--- a/circuits/Sudoku/circuits/Nargo.toml
+++ b/circuits/Sudoku/circuits/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name = "sudoku"
 authors = ["RareSkills"]
 compiler_version = "0.4.1"
+type = "bin"
 
 [dependencies]

--- a/circuits/Sujiko/circuits/Nargo.toml
+++ b/circuits/Sujiko/circuits/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name = "sujiko"
 authors = ["RareSkills"]
 compiler_version = "0.4.1"
+type = "bin"
 
 [dependencies]

--- a/circuits/Typecast/Nargo.toml
+++ b/circuits/Typecast/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name = "typecast"
 authors = ["RareSkills"]
 compiler_version = "0.4.1"
+type = "bin"
 
 [dependencies]


### PR DESCRIPTION
When running `nargo test` inside any puzzle circuit using the following noir version:
`nargo 0.10.5 (git version hash: 5f78772fefdc84b67f28fe8b671a56e280313f38, is dirty: false)` it requires adding the field `name` and `type` to `Nargo.toml`.

Fix #29